### PR TITLE
fix: add system_explain to revision generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def generate_command(prompt, system_command="", system_explain=""):
       return command
   elif action == "📝 revise query":
     revision_prompt = input("Revision: ")
-    return generate_command(f"Change this command: {command}\nwith these edits: {revision_prompt}", system_command)
+    return generate_command(f"Change this command: {command}\nwith these edits: {revision_prompt}", system_command, system_explain)
   else:
     return None
 


### PR DESCRIPTION
When revising, the explanation for the command doesn't follow the same format as the initial command.

### How To Reproduce

1. Run `python main.py list all files in the current directory`
2. Choose "Revise query"
3. Type "include file size"
4. The explanation for the command will not follow the same format as before

### Demonstration

**Before:**
![Screenshot 2023-11-30 at 19 04 57](https://github.com/othema/command-ai/assets/684179/b67053dc-5d09-4ba8-a824-177a0c33dd5a)

**After:**
![Screenshot 2023-11-30 at 19 08 39](https://github.com/othema/command-ai/assets/684179/e805e6c3-4b97-4df4-a6c1-8926bb9959af)